### PR TITLE
laurel_sprout: Track shrp devices repo instead of personal one

### DIFF
--- a/laurel_sprout.sh
+++ b/laurel_sprout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 git clone https://github.com/LineageOS/android_hardware_qcom_bootctrl.git -b lineage-16.0 hardware/qcom/bootctrl
-git clone https://github.com/oddlyspaced/shrp_xiaomi_laurel_sprout.git device/xiaomi/laurel_sprout
+git clone https://github.com/SHRP-Devices/device_xiaomi_laurel_sprout.git device/xiaomi/laurel_sprout
 . build/envsetup.sh
 lunch omni_laurel_sprout-eng
 mka bootimage


### PR DESCRIPTION
This is to ensure that future builds will be tracked from the official shrp devices repo and not from my personal account.