### PR TITLE
ci: Switch device codename for Redmi 7/Y3

### DIFF
--- a/onc.sh
+++ b/onc.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone https://github.com/SHRP-Devices/android_device_xiaomi_onc --depth=1 device/xiaomi/onc
+git clone https://github.com/omnirom/android_vendor_qcom_opensource_commonsys -b android-9.0 vendor/qcom/opensource/commonsys
+source build/envsetup.sh
+lunch omni_onc-eng
+mka recoveryimage

--- a/onclite.sh
+++ b/onclite.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-git clone https://github.com/SHRP-Devices/android_device_xiaomi_onclite.git --depth=1 device/xiaomi/onclite
-git clone https://github.com/omnirom/android_vendor_qcom_opensource_commonsys -b android-9.0 vendor/qcom/opensource/commonsys
-git clone https://github.com/omnirom/android_device_qcom_caf-sepolicy.git -b android-9.0 device/qcom/sepolicy
-source build/envsetup.sh
-lunch omni_onclite-eng
-mka recoveryimage


### PR DESCRIPTION
* There are Redmi 7 and Redmi Y3, both are same, only different from specific camera
  Both use same base rom (miui), even same cusrom it can run on both

* Also same kernel source from miui
  https://github.com/MiCode/Xiaomi_Kernel_OpenSource/tree/onc-q-oss

* Redmi 7 = onclite, Redmi Y3 = onc

* But on miui (stock) use one codename "onc"

* Change codename "onclite" to "onc" so that device release become "Redmi 7/Y3 (onc)"

* Also prepared a new tree for this, also tested on Redmi Y3 by several tester using Y3, and it works

* New device tree
  https://github.com/SHRP-Devices/android_device_xiaomi_onc